### PR TITLE
main: add proper --help support

### DIFF
--- a/multihash/main.go
+++ b/multihash/main.go
@@ -23,6 +23,7 @@ var checkRaw string
 var checkMh mh.Multihash
 var inputFilename string
 var quiet bool
+var help bool
 
 func init() {
 	flag.Usage = func() {
@@ -35,6 +36,10 @@ func init() {
 	checkStr := "check checksum matches"
 	flag.StringVar(&checkRaw, "check", "", checkStr)
 	flag.StringVar(&checkRaw, "c", "", checkStr+" (shorthand)")
+
+	helpStr := "display help message"
+	flag.BoolVar(&help, "help", false, helpStr)
+	flag.BoolVar(&help, "h", false, helpStr+" (shorthand)")
 
 	quietStr := "quiet output (no newline on checksum, no error text)"
 	flag.BoolVar(&quiet, "quiet", false, quietStr)
@@ -105,6 +110,11 @@ func main() {
 
 	err := parseFlags(opts)
 	checkErr(err)
+
+	if help {
+		flag.Usage()
+		os.Exit(0)
+	}
 
 	inp, err := getInput()
 	checkErr(err)

--- a/test/sharness/t0010-basics.sh
+++ b/test/sharness/t0010-basics.sh
@@ -17,9 +17,9 @@ test_expect_success "multihash is available" '
 '
 
 test_expect_success "multihash help output looks good" '
-	test_must_fail multihash -h 2>help.txt &&
-	cat help.txt | egrep -i "^usage:" >/dev/null &&
-	cat help.txt | egrep -i "multihash .*options.*file" >/dev/null
+	multihash -h 2>help.txt &&
+	egrep -i "^usage:" help.txt >/dev/null &&
+	egrep -i "multihash .*options.*file" help.txt >/dev/null
 '
 
 test_done


### PR DESCRIPTION
I think when -h or --help are passed, the exit code should be 0.
Also -h and --help should be displayed in the usage message.

This addresses some points I noted in issue https://github.com/jbenet/go-multihash/issues/18