### PR TITLE
add keccak256 for ethereum

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -33,10 +33,14 @@ func (e ErrInconsistentLen) Error() string {
 
 // constants
 const (
-	SHA1     = 0x11
-	SHA2_256 = 0x12
-	SHA2_512 = 0x13
-	SHA3     = 0x14
+	SHA1       = 0x11
+	SHA2_256   = 0x12
+	SHA2_512   = 0x13
+	SHA3       = 0x14
+	KECCAK_224 = 0x1A
+	KECCAK_256 = 0x1B
+	KECCAK_384 = 0x1C
+	KECCAK_512 = 0x1D
 
 	BLAKE2B_MIN = 0xb201
 	BLAKE2B_MAX = 0xb240
@@ -73,6 +77,7 @@ var Names = map[string]uint64{
 	"sha2-512":     SHA2_512,
 	"sha3":         SHA3,
 	"dbl-sha2-256": DBL_SHA2_256,
+	"keccak-256":   KECCAK_256,
 }
 
 // Codes maps a hash code to it's name
@@ -82,6 +87,7 @@ var Codes = map[uint64]string{
 	SHA2_512:     "sha2-512",
 	SHA3:         "sha3",
 	DBL_SHA2_256: "dbl-sha2-256",
+	KECCAK_256:   "keccak-256",
 }
 
 // DefaultLengths maps a hash code to it's default length
@@ -91,6 +97,7 @@ var DefaultLengths = map[uint64]int{
 	SHA2_512:     64,
 	SHA3:         64,
 	DBL_SHA2_256: 32,
+	KECCAK_256:   32,
 }
 
 func uvarint(buf []byte) (uint64, []byte, error) {

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -16,6 +16,7 @@ var tCodes = map[uint64]string{
 	0x13: "sha2-512",
 	0x14: "sha3",
 	0x56: "dbl-sha2-256",
+	0x1B: "keccak-256",
 }
 
 type TestCase struct {

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -31,6 +31,7 @@ var testCases = []TestCase{
 	TestCase{"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", 0x12, "sha2-256"},
 	TestCase{"2c26b46b", 0x12, "sha2-256"},
 	TestCase{"2c26b46b68ffc68ff99b453c1d30413413", 0xb240, "blake2b-512"},
+	TestCase{"f00ba4", 0x1b, "keccak-256"},
 }
 
 func (tc TestCase) Multihash() (Multihash, error) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
       "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
       "name": "go-base58",
       "version": "0.0.0"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmdKCKycEwt8S5vZM5LQ96a3hCLQ5WF98z21wJFBBX8pJe",
+      "name": "keccak",
+      "version": "0.0.0"
     }
   ],
   "gxVersion": "0.9.0",

--- a/sum.go
+++ b/sum.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	keccak "github.com/ethereum/go-ethereum/crypto/sha3"
 	blake2b "golang.org/x/crypto/blake2b"
 	blake2s "golang.org/x/crypto/blake2s"
 	sha3 "golang.org/x/crypto/sha3"
@@ -63,6 +64,8 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 			d = sumSHA256(data)
 		case SHA2_512:
 			d = sumSHA512(data)
+		case KECCAK_256:
+			d = sumKeccak256(data)
 		case SHA3:
 			d, err = sumSHA3(data)
 		case DBL_SHA2_256:
@@ -97,6 +100,12 @@ func sumSHA256(data []byte) []byte {
 func sumSHA512(data []byte) []byte {
 	a := sha512.Sum512(data)
 	return a[0:64]
+}
+
+func sumKeccak256(data []byte) []byte {
+	h := keccak.NewKeccak256()
+	h.Write(data)
+	return h.Sum(nil)
 }
 
 func sumSHA3(data []byte) ([]byte, error) {

--- a/sum_test.go
+++ b/sum_test.go
@@ -27,6 +27,7 @@ var sumTestCases = []SumTestCase{
 	SumTestCase{BLAKE2B_MAX - 32, 32, "foo", "a0e40220b8fe9f7f6255a6fa08f668ab632a8d081ad87983c77cd274e48ce450f0b349fd"},
 	SumTestCase{BLAKE2B_MAX - 16, 32, "foo", "b0e40220e629ee880953d32c8877e479e3b4cb0a4c9d5805e2b34c675b5a5863c4ad7d64"},
 	SumTestCase{BLAKE2S_MAX, 32, "foo", "e0e4022008d6cad88075de8f192db097573d0e829411cd91eb6ec65e8fc16c017edfdb74"},
+	SumTestCase{KECCAK_256, 32, "foo", "1b2041b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d"},
 }
 
 func TestSum(t *testing.T) {


### PR DESCRIPTION
For some reason the ethereum crew decided to use a non-standardized hash function to base their entire system off of. This adds support for it.