### PR TITLE
Set the default length of the ID hash function to -1

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -126,7 +126,7 @@ var Codes = map[uint64]string{
 
 // DefaultLengths maps a hash code to it's default length
 var DefaultLengths = map[uint64]int{
-	ID:           32,
+	ID:           -1,
 	SHA1:         20,
 	SHA2_256:     32,
 	SHA2_512:     64,

--- a/sum.go
+++ b/sum.go
@@ -102,7 +102,10 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 	if err != nil {
 		return m, err
 	}
-	return Encode(d[0:length], code)
+	if length >= 0 {
+		d = d[:length]
+	}
+	return Encode(d, code)
 }
 
 func isBlake2s(code uint64) bool {

--- a/sum_test.go
+++ b/sum_test.go
@@ -15,6 +15,7 @@ type SumTestCase struct {
 
 var sumTestCases = []SumTestCase{
 	SumTestCase{ID, 3, "foo", "0003666f6f"},
+	SumTestCase{ID, -1, "foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo", "0030666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f666f6f"},
 	SumTestCase{SHA1, -1, "foo", "11140beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"},
 	SumTestCase{SHA1, 10, "foo", "110a0beec7b5ea3f0fdbc95d"},
 	SumTestCase{SHA2_256, -1, "foo", "12202c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"},


### PR DESCRIPTION
Truncating to 32bits by default is a bit arbitrary and is guaranteed to make unsuspecting users very unhappy.