### PR TITLE
use a faster base58 library

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"math"
 
-	b58 "github.com/jbenet/go-base58"
+	b58 "github.com/mr-tron/base58/base58"
 )
 
 // errors
@@ -197,17 +197,8 @@ func (m Multihash) B58String() string {
 
 // FromB58String parses a B58-encoded multihash.
 func FromB58String(s string) (m Multihash, err error) {
-	// panic handler, in case we try accessing bytes incorrectly.
-	defer func() {
-		if e := recover(); e != nil {
-			m = Multihash{}
-			err = e.(error)
-		}
-	}()
-
-	//b58 smells like it can panic...
-	b := b58.Decode(s)
-	if len(b) == 0 {
+	b, err := b58.Decode(s)
+	if err != nil {
 		return Multihash{}, ErrInvalidMultihash
 	}
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
       "version": "0.0.0"
     },
     {
-      "author": "whyrusleeping",
-      "hash": "QmT8rehPR3F6bmwL6zjUN8XpiDBFFpMP2myPdC6ApsWfJf",
-      "name": "go-base58",
-      "version": "0.0.0"
+      "author": "mr-tron",
+      "hash": "QmWFAMPqsEyUX7gDUsRVmMWz59FxSpJ1b2v6bJ1yYzo7jY",
+      "name": "go-base58-fast",
+      "version": "0.1.1"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
An `encode(decode(x)) == x`:

1. Is 8-10x faster.
2. Does 6 allocations (3 on decode, 3 on encode) versus 238 (yes, that's per multihash decode + encode).