### PR TITLE
Change minimum length of multihash to 2 bytes

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -16,7 +16,7 @@ import (
 // errors
 var (
 	ErrUnknownCode      = errors.New("unknown multihash code")
-	ErrTooShort         = errors.New("multihash too short. must be > 3 bytes")
+	ErrTooShort         = errors.New("multihash too short. must be >= 2 bytes")
 	ErrTooLong          = errors.New("multihash too long. must be < 129 bytes")
 	ErrLenNotSupported  = errors.New("multihash does not yet support digests longer than 127 bytes")
 	ErrInvalidMultihash = errors.New("input isn't valid multihash")
@@ -223,7 +223,7 @@ func Cast(buf []byte) (Multihash, error) {
 // Decode parses multihash bytes into a DecodedMultihash.
 func Decode(buf []byte) (*DecodedMultihash, error) {
 
-	if len(buf) < 3 {
+	if len(buf) < 2 {
 		return nil, ErrTooShort
 	}
 

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -37,6 +37,7 @@ type TestCase struct {
 
 var testCases = []TestCase{
 	TestCase{"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", 0x00, "id"},
+	TestCase{"", 0x00, "id"},
 	TestCase{"0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33", 0x11, "sha1"},
 	TestCase{"0beec7b5", 0x11, "sha1"},
 	TestCase{"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae", 0x12, "sha2-256"},


### PR DESCRIPTION
to accommodate 0 length id (0x00) hashes.

Closes #69.