### PR TITLE
sum: check length of identity hash

### DIFF
--- a/sum.go
+++ b/sum.go
@@ -52,7 +52,7 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 	default:
 		switch code {
 		case ID:
-			d = sumID(data)
+			d, err = sumID(data, length)
 		case SHA1:
 			d = sumSHA1(data)
 		case SHA2_256:
@@ -116,8 +116,13 @@ func sumBlake2b(size uint8, data []byte) []byte {
 	return hasher.Sum(nil)[:]
 }
 
-func sumID(data []byte) []byte {
-	return data
+func sumID(data []byte, length int) ([]byte, error) {
+	if length >= 0 && length != len(data) {
+		return nil, fmt.Errorf("the length of the identity hash (%d) must be equal to the length of the data (%d)",
+			length, len(data))
+
+	}
+	return data, nil
 }
 
 func sumSHA1(data []byte) []byte {

--- a/sum_test.go
+++ b/sum_test.go
@@ -120,3 +120,33 @@ func BenchmarkBlake2B(b *testing.B) {
 		}(s)
 	}
 }
+
+// Test that the identity hash function checks
+// its `length` arguemnt for values that are
+// different to its `data` length.
+func TestSmallerLengthHashID(t *testing.T) {
+
+	data := []byte("Identity hash input data.")
+	dataLength := len(data)
+
+	// Normal case: `length == len(data)`.
+	_, err := sumID(data, dataLength)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unconstrained length (-1): also allowed.
+	_, err = sumID(data, -1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Any other variation of those two scenarios should fail.
+	for l := (dataLength - 1); l >= 0; l-- {
+		_, err = sumID(data, l)
+		if err == nil {
+			t.Fatal(fmt.Sprintf("identity hash of length %d smaller than data length %d didn't fail",
+				l, dataLength))
+		}
+	}
+}


### PR DESCRIPTION
Towards https://github.com/ipfs/go-ipfs/issues/5019.

[Edit by kevina to avoid using words that will automatically close a bug in a different repo as this won't fix the bug until it a version with this fix is published and the gx dependency is updated in `go-ipfs`)
