### PR TITLE
make multihash pluggable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install:
   - make deps

--- a/sum.go
+++ b/sum.go
@@ -53,7 +53,7 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 		}
 	case isBlake2b(code):
 		olen := uint8(code - BLAKE2B_MIN + 1)
-		d = sumBlake2b(olen, data)
+		d, err = sumBlake2b(data, olen)
 	default:
         hashFunc, ok := funcTable[code]
         if !ok {
@@ -77,17 +77,17 @@ func isBlake2b(code uint64) bool {
 	return code >= BLAKE2B_MIN && code <= BLAKE2B_MAX
 }
 
-func sumBlake2b(size uint8, data []byte) []byte {
+func sumBlake2b(data []byte, size uint8) ([]byte, error) {
 	hasher, err := blake2b.New(&blake2b.Config{Size: size})
 	if err != nil {
-		panic(err)
+		return []byte{}, err
 	}
 
 	if _, err := hasher.Write(data); err != nil {
-		panic(err)
+		return []byte{}, err
 	}
 
-	return hasher.Sum(nil)[:]
+	return hasher.Sum(nil)[:], nil
 }
 
 func sumID(data []byte, length int) ([]byte, error) {

--- a/sum.go
+++ b/sum.go
@@ -50,6 +50,8 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 		size = int(code - BLAKE2S_MIN + 1)
 	case isBlake2b(code):
 		size = int(code - BLAKE2B_MIN + 1)
+	case ID:
+		size = length
 	default:
 		size = len(data)
 	}

--- a/sum.go
+++ b/sum.go
@@ -51,13 +51,6 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 	return Encode(d, code)
 }
 
-func isBlake2s(code uint64) bool {
-	return code >= BLAKE2S_MIN && code <= BLAKE2S_MAX
-}
-func isBlake2b(code uint64) bool {
-	return code >= BLAKE2B_MIN && code <= BLAKE2B_MAX
-}
-
 func sumBlake2s(data []byte, size int) ([]byte, error) {
 	if size != 32 {
 		return nil, fmt.Errorf("unsupported length for blake2s: %d", size)

--- a/sum.go
+++ b/sum.go
@@ -80,11 +80,11 @@ func sumBlake2s(data []byte, size int) ([]byte, error) {
 func sumBlake2b(data []byte, size int) ([]byte, error) {
 	hasher, err := blake2b.New(&blake2b.Config{Size: uint8(size)})
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	if _, err := hasher.Write(data); err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 
 	return hasher.Sum(nil)[:], nil
@@ -227,6 +227,8 @@ func init() {
 }
 
 // RegisterHashFunc adds an entry to the package-level code -> hash func map.
+// The hash function must return at least the requested number of bytes. If it
+// returns more, the hash will be truncated.
 func RegisterHashFunc(code uint64, hashFunc func([]byte, int) ([]byte, error)) error {
 	if !ValidCode(code) {
 		return fmt.Errorf("code %v not valid", code)

--- a/sum.go
+++ b/sum.go
@@ -24,29 +24,26 @@ var funcTable = make(map[uint64]func([]byte, int) ([]byte, error))
 // indicates the length of the resulting digest and passing a negative value
 // use default length values for the selected hash function.
 func Sum(data []byte, code uint64, length int) (Multihash, error) {
-	m := Multihash{}
-	err := error(nil)
 	if !ValidCode(code) {
-		return m, fmt.Errorf("invalid multihash code %d", code)
+		return nil, fmt.Errorf("invalid multihash code %d", code)
 	}
 
 	if length < 0 {
 		var ok bool
 		length, ok = DefaultLengths[code]
 		if !ok {
-			return m, fmt.Errorf("no default length for code %d", code)
+			return nil, fmt.Errorf("no default length for code %d", code)
 		}
 	}
 
-	var d []byte
 	hashFunc, ok := funcTable[code]
 	if !ok {
-		return m, ErrSumNotSupported
+		return nil, ErrSumNotSupported
 	}
 
-	d, err = hashFunc(data, length)
+	d, err := hashFunc(data, length)
 	if err != nil {
-		return m, err
+		return nil, err
 	}
 	if length >= 0 {
 		d = d[:length]

--- a/sum.go
+++ b/sum.go
@@ -55,16 +55,11 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 		olen := uint8(code - BLAKE2B_MIN + 1)
 		d = sumBlake2b(olen, data)
 	default:
-		switch code {
-		case ID:
-			d, err = sumID(data, length)
-		default:
-			hashFunc, ok := funcTable[code]
-			if !ok {
-				return m, ErrSumNotSupported
-			}
-			d, err = hashFunc(data, len(data))
-		}
+        hashFunc, ok := funcTable[code]
+        if !ok {
+            return m, ErrSumNotSupported
+        }
+        d, err = hashFunc(data, len(data))
 	}
 	if err != nil {
 		return m, err
@@ -191,6 +186,7 @@ func sumSHA3_224(data []byte, length int) ([]byte, error) {
 }
 
 func registerStdlibHashFuncs() {
+	RegisterHashFunc(ID, sumID)
 	RegisterHashFunc(SHA1, sumSHA1)
 	RegisterHashFunc(SHA2_512, sumSHA512)
 }

--- a/sum.go
+++ b/sum.go
@@ -44,18 +44,7 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 		return m, ErrSumNotSupported
 	}
 
-	var size int
-	switch {
-	case isBlake2s(code):
-		size = int(code - BLAKE2S_MIN + 1)
-	case isBlake2b(code):
-		size = int(code - BLAKE2B_MIN + 1)
-	case ID:
-		size = length
-	default:
-		size = len(data)
-	}
-	d, err = hashFunc(data, size)
+	d, err = hashFunc(data, length)
 	if err != nil {
 		return m, err
 	}
@@ -215,11 +204,17 @@ func registerNonStdlibHashFuncs() {
 	// Blake family of hash functions
 	// BLAKE2S
 	for c := uint64(BLAKE2S_MIN); c <= BLAKE2S_MAX; c++ {
-		RegisterHashFunc(c, sumBlake2s)
+		size := int(c - BLAKE2S_MIN + 1)
+		RegisterHashFunc(c, func(buf []byte, _ int) ([]byte, error) {
+			return sumBlake2s(buf, size)
+		})
 	}
 	// BLAKE2B
 	for c := uint64(BLAKE2B_MIN); c <= BLAKE2B_MAX; c++ {
-		RegisterHashFunc(c, sumBlake2b)
+		size := int(c - BLAKE2B_MIN + 1)
+		RegisterHashFunc(c, func(buf []byte, _ int) ([]byte, error) {
+			return sumBlake2b(buf, size)
+		})
 	}
 }
 

--- a/sum.go
+++ b/sum.go
@@ -17,8 +17,16 @@ import (
 // ErrSumNotSupported is returned when the Sum function code is not implemented
 var ErrSumNotSupported = errors.New("Function not implemented. Complain to lib maintainer.")
 
+// HashFunc is a hash function that hashes data into digest.
+//
+// The length is the size the digest will be truncated to. While the hash
+// function isn't responsible for truncating the digest, it may want to error if
+// the length is invalid for the hash function (e.g., truncation would make the
+// hash useless).
+type HashFunc func(data []byte, length int) (digest []byte, err error)
+
 // funcTable maps multicodec values to hash functions.
-var funcTable = make(map[uint64]func([]byte, int) ([]byte, error))
+var funcTable = make(map[uint64]HashFunc)
 
 // Sum obtains the cryptographic sum of a given buffer. The length parameter
 // indicates the length of the resulting digest and passing a negative value
@@ -216,7 +224,7 @@ func init() {
 // RegisterHashFunc adds an entry to the package-level code -> hash func map.
 // The hash function must return at least the requested number of bytes. If it
 // returns more, the hash will be truncated.
-func RegisterHashFunc(code uint64, hashFunc func([]byte, int) ([]byte, error)) error {
+func RegisterHashFunc(code uint64, hashFunc HashFunc) error {
 	if !ValidCode(code) {
 		return fmt.Errorf("code %v not valid", code)
 	}

--- a/sum_test.go
+++ b/sum_test.go
@@ -150,3 +150,27 @@ func TestSmallerLengthHashID(t *testing.T) {
 		}
 	}
 }
+
+// Ensure that invalid codecs can't be registered, and existing hash funcs
+// won't be overwritten.
+func TestRegisterHashFunc(t *testing.T) {
+	tests := []struct {
+		code      uint64
+		shouldErr bool
+	}{
+		{ID, false},
+		{9999, true},
+		{SHA1, true},
+	}
+
+	doesNothing := func(data []byte) []byte {
+		return []byte{}
+	}
+
+	for _, tt := range tests {
+		err := RegisterHashFunc(tt.code, doesNothing)
+		if err != nil && !tt.shouldErr {
+			t.Error(err)
+		}
+	}
+}

--- a/sum_test.go
+++ b/sum_test.go
@@ -158,7 +158,6 @@ func TestRegisterHashFunc(t *testing.T) {
 		code      uint64
 		shouldErr bool
 	}{
-		{ID, false},
 		{9999, true},
 		{SHA1, true},
 	}

--- a/sum_test.go
+++ b/sum_test.go
@@ -163,8 +163,8 @@ func TestRegisterHashFunc(t *testing.T) {
 		{SHA1, true},
 	}
 
-	doesNothing := func(data []byte) []byte {
-		return []byte{}
+	doesNothing := func(data []byte, length int) ([]byte, error) {
+		return []byte{}, nil
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This adds the ability to register hash funcs independently and not required them in this library.

Note: this is a suggestion/WIP which can be refactored as needed.

This adds a map var which maps codecs to hash functions. The hash funcs must
have signature ~which accepts one byte slice, and returns one byte slice~ : `func(data []byte, length int) ([]byte, error)`.

It adds a RegisterHashFunc method which allows registration for any valid
codec. It prevents double registration or overwriting of hash funcs already
registered.

It also creates two funcs which are called by init() to register the funcs
which is already the current behaviour of the code:

  * registerStdlibHashFuncs
  * registerNonStdlibHashFuncs

If desired, the non-stdlib funcs can then easily be removed. Or it can be
implemented as-is, and required that future hash funcs use the Registration
func. Or refactored in some other way if necessary.

I have tested this and it is working with IPLD Dash resolver. Can also add
example in the README if this is approved / agreed.

Note: this is based upon 'cleanup' PR, #87 and needs to wait on that to be merged before this one. I can rebase after merged.

Fixes #78.