### PR TITLE
remove app codes

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -288,18 +288,6 @@ func EncodeName(buf []byte, name string) ([]byte, error) {
 
 // ValidCode checks whether a multihash code is valid.
 func ValidCode(code uint64) bool {
-	if AppCode(code) {
-		return true
-	}
-
-	if _, ok := Codes[code]; ok {
-		return true
-	}
-
-	return false
-}
-
-// AppCode checks whether a multihash code is part of the App range.
-func AppCode(code uint64) bool {
-	return code >= 0 && code < 0x10
+	_, ok := Codes[code]
+	return ok
 }

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -190,19 +190,9 @@ func ExampleDecode() {
 func TestValidCode(t *testing.T) {
 	for i := uint64(0); i < 0xff; i++ {
 		_, ok := tCodes[i]
-		b := AppCode(i) || ok
 
-		if ValidCode(i) != b {
+		if ValidCode(i) != ok {
 			t.Error("ValidCode incorrect for: ", i)
-		}
-	}
-}
-
-func TestAppCode(t *testing.T) {
-	for i := uint64(0); i < 0xff; i++ {
-		b := i >= 0 && i < 0x10
-		if AppCode(i) != b {
-			t.Error("AppCode incorrect for: ", i)
 		}
 	}
 }


### PR DESCRIPTION
These were never used. Worse, other codecs have been allocated into this range
so they probably *can't* be used.

See: https://github.com/multiformats/multihash/issues/111