### PR TITLE
Small Encoding Performance Improvement

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -271,7 +271,7 @@ func Encode(buf []byte, code uint64) ([]byte, error) {
 		return nil, ErrUnknownCode
 	}
 
-	start := make([]byte, 2*binary.MaxVarintLen64)
+	start := make([]byte, 2*binary.MaxVarintLen64, 2*binary.MaxVarintLen64+len(buf))
 	spot := start
 	n := binary.PutUvarint(spot, code)
 	spot = start[n:]


### PR DESCRIPTION
Improve encoding performance by pre-allocating the buffer and thus avoiding un-needed allocations.

## Benchmarks

**system**
```
goos: darwin
goarch: amd64
go version: go1.11.5 darwin/amd64
Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz
```

**benchcmp**
```
benchmark                          old ns/op     new ns/op     delta
BenchmarkEncode-8                  70.3          40.8          -41.96%
BenchmarkDecode-8                  70.4          72.1          +2.41%
BenchmarkSum-8                     78.9          79.6          +0.89%
BenchmarkBlake2B/blake2b-128-8     506           520           +2.77%
BenchmarkBlake2B/blake2b-129-8     512           506           -1.17%
BenchmarkBlake2B/blake2b-130-8     511           503           -1.57%
BenchmarkBlake2B/blake2b-255-8     552           516           -6.52%
BenchmarkBlake2B/blake2b-256-8     559           507           -9.30%
BenchmarkBlake2B/blake2b-257-8     557           510           -8.44%
BenchmarkBlake2B/blake2b-386-8     590           551           -6.61%
BenchmarkBlake2B/blake2b-512-8     587           553           -5.79%

benchmark                          old allocs     new allocs     delta
BenchmarkBlake2B/blake2b-128-8     3              3              +0.00%
BenchmarkBlake2B/blake2b-129-8     3              3              +0.00%
BenchmarkBlake2B/blake2b-130-8     3              3              +0.00%
BenchmarkBlake2B/blake2b-255-8     4              3              -25.00%
BenchmarkBlake2B/blake2b-256-8     4              3              -25.00%
BenchmarkBlake2B/blake2b-257-8     4              3              -25.00%
BenchmarkBlake2B/blake2b-386-8     4              3              -25.00%
BenchmarkBlake2B/blake2b-512-8     4              3              -25.00%

benchmark                          old bytes     new bytes     delta
BenchmarkBlake2B/blake2b-128-8     496           512           +3.23%
BenchmarkBlake2B/blake2b-129-8     496           512           +3.23%
BenchmarkBlake2B/blake2b-130-8     496           512           +3.23%
BenchmarkBlake2B/blake2b-255-8     560           544           -2.86%
BenchmarkBlake2B/blake2b-256-8     560           544           -2.86%
BenchmarkBlake2B/blake2b-257-8     560           544           -2.86%
BenchmarkBlake2B/blake2b-386-8     592           576           -2.70%
BenchmarkBlake2B/blake2b-512-8     624           608           -2.56%
```

**before**
```
BenchmarkEncode-8    	50000000	        69.2 ns/op
BenchmarkDecode-8    	100000000	        69.6 ns/op
BenchmarkSum-8       	50000000	        78.6 ns/op
BenchmarkBlake2B/blake2b-128-8         	10000000	       509 ns/op	     496 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-129-8         	10000000	       507 ns/op	     496 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-130-8         	10000000	       507 ns/op	     496 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-255-8         	10000000	       551 ns/op	     560 B/op	       4 allocs/op
BenchmarkBlake2B/blake2b-256-8         	10000000	       549 ns/op	     560 B/op	       4 allocs/op
BenchmarkBlake2B/blake2b-257-8         	10000000	       552 ns/op	     560 B/op	       4 allocs/op
BenchmarkBlake2B/blake2b-386-8         	10000000	       565 ns/op	     592 B/op	       4 allocs/op
BenchmarkBlake2B/blake2b-512-8         	10000000	       582 ns/op	     624 B/op	       4 allocs/op
```

**after**
```
BenchmarkEncode-8    	100000000	        41.1 ns/op
BenchmarkDecode-8    	100000000	        69.2 ns/op
BenchmarkSum-8       	50000000	        81.8 ns/op
BenchmarkBlake2B/blake2b-128-8         	10000000	       506 ns/op	     512 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-129-8         	10000000	       503 ns/op	     512 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-130-8         	10000000	       499 ns/op	     512 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-255-8         	10000000	       524 ns/op	     544 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-256-8         	10000000	       528 ns/op	     544 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-257-8         	10000000	       524 ns/op	     544 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-386-8         	10000000	       539 ns/op	     576 B/op	       3 allocs/op
BenchmarkBlake2B/blake2b-512-8         	10000000	       544 ns/op	     608 B/op	       3 allocs/op
```