### PR TITLE
ValidCode Contains Incorrect Logic And Will Always Be True

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -293,6 +293,6 @@ func EncodeName(buf []byte, name string) ([]byte, error) {
 
 // ValidCode checks whether a multihash code is valid.
 func ValidCode(code uint64) bool {
-	_, ok := Codes[code]
-	return ok
+	val := Codes[code]
+	return val != ""
 }

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -191,9 +191,9 @@ func ExampleDecode() {
 
 func TestValidCode(t *testing.T) {
 	for i := uint64(0); i < 0xff; i++ {
-		_, ok := tCodes[i]
+		val := tCodes[i]
 
-		if ValidCode(i) != ok {
+		if ValidCode(i) && val == "" {
 			t.Error("ValidCode incorrect for: ", i)
 		}
 	}


### PR DESCRIPTION
The way `ValidCode` was performing validation is incorrect. The check that is being done( `_, ok := Codes[code]`) regardless of whatever input value is given, will always be true, because if a key doesn't exist, we will be given the default value of `uint64` and thus `ok` will always be valid. Instead, we should be performing a check against the returned value, ensuring that it is not the empty value.


With the old version of `ValidCode` anything, including stuff like `sha999-999` would pass validation