### PR TITLE
feat: reduce blake2b allocations by special-casing the 256/512 variants

### DIFF
--- a/sum.go
+++ b/sum.go
@@ -73,6 +73,17 @@ func sumBlake2s(data []byte, size int) ([]byte, error) {
 	return d[:], nil
 }
 func sumBlake2b(data []byte, size int) ([]byte, error) {
+	// special case these lengths to avoid allocations.
+	switch size {
+	case 32:
+		hash := blake2b.Sum256(data)
+		return hash[:], nil
+	case 64:
+		hash := blake2b.Sum512(data)
+		return hash[:], nil
+	}
+
+	// Ok, allocate away.
 	hasher, err := blake2b.New(&blake2b.Config{Size: uint8(size)})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
These special-case functions don't allocate internally.