### PR TITLE
Add func SumStreamN for hashing first n bytes only

### DIFF
--- a/sum.go
+++ b/sum.go
@@ -48,6 +48,24 @@ func SumStream(r io.Reader, code uint64, length int) (Multihash, error) {
 	return encodeHash(hasher, code, length)
 }
 
+// SumStreamN obtains the cryptographic sum of first n bytes of a given stream. 
+// The length parameter indicates the length of the resulting digest. Passing 
+// a negative value uses default length values for the selected hash function.
+func SumStreamN(r io.Reader, n int64, code uint64, length int) (Multihash, error) {
+	// Get the algorithm.
+	hasher, err := GetHasher(code)
+	if err != nil {
+		return nil, err
+	}
+
+	// Feed data in.
+	if _, err = io.CopyN(hasher, r, n); err != nil {
+		return nil, err
+	}
+
+	return encodeHash(hasher, code, length)
+}
+
 func encodeHash(hasher hash.Hash, code uint64, length int) (Multihash, error) {
 	// Compute final hash.
 	//  A new slice is allocated.  FUTURE: see other comment below about allocation, and review together with this line to try to improve.


### PR DESCRIPTION
`func SumStreamN(r io.Reader, n int64, code uint64, length int) (Multihash, error)` that uses io.CopyN instead of io.Copy