### PR TITLE
Add blake3 hash and sharness tests

### DIFF
--- a/core/magic.go
+++ b/core/magic.go
@@ -19,6 +19,7 @@ const (
 	KECCAK_256   = 0x1B
 	KECCAK_384   = 0x1C
 	KECCAK_512   = 0x1D
+	BLAKE3       = 0x1E
 	SHAKE_128    = 0x18
 	SHAKE_256    = 0x19
 	MD5          = 0xd5

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/multiformats/go-varint v0.0.6
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
+	lukechampine.com/blake3 v1.1.5
 )
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/multiformats/go-varint v0.0.6
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
-	lukechampine.com/blake3 v1.1.5
+	lukechampine.com/blake3 v1.1.6
 )
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
-github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
-github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
-github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
@@ -20,5 +19,5 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEq
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-lukechampine.com/blake3 v1.1.5 h1:hsACfxWvLdGmjYbWGrumQIphOvO+ZruZehWtgd2fxoM=
-lukechampine.com/blake3 v1.1.5/go.mod h1:hE8RpzdO8ttZ7446CXEwDP1eu2V4z7stv0Urj1El20g=
+lukechampine.com/blake3 v1.1.6 h1:H3cROdztr7RCfoaTpGZFQsrqvweFLrqS73j7L7cmR5c=
+lukechampine.com/blake3 v1.1.6/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
+github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
 github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
@@ -18,3 +20,5 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 h1:46ULzRKLh1CwgRq2dC5SlBzEq
 golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+lukechampine.com/blake3 v1.1.5 h1:hsACfxWvLdGmjYbWGrumQIphOvO+ZruZehWtgd2fxoM=
+lukechampine.com/blake3 v1.1.5/go.mod h1:hE8RpzdO8ttZ7446CXEwDP1eu2V4z7stv0Urj1El20g=

--- a/multihash.go
+++ b/multihash.go
@@ -51,6 +51,7 @@ const (
 	KECCAK_256 = 0x1B
 	KECCAK_384 = 0x1C
 	KECCAK_512 = 0x1D
+	BLAKE3     = 0x1E
 
 	SHAKE_128 = 0x18
 	SHAKE_256 = 0x19
@@ -108,6 +109,7 @@ var Names = map[string]uint64{
 	"keccak-256":                KECCAK_256,
 	"keccak-384":                KECCAK_384,
 	"keccak-512":                KECCAK_512,
+	"blake3":                    BLAKE3,
 	"shake-128":                 SHAKE_128,
 	"shake-256":                 SHAKE_256,
 	"sha2-256-trunc254-padded":  SHA2_256_TRUNC254_PADDED,
@@ -132,6 +134,7 @@ var Codes = map[uint64]string{
 	KECCAK_256:                "keccak-256",
 	KECCAK_384:                "keccak-384",
 	KECCAK_512:                "keccak-512",
+	BLAKE3:                    "blake3",
 	SHAKE_128:                 "shake-128",
 	SHAKE_256:                 "shake-256",
 	SHA2_256_TRUNC254_PADDED:  "sha2-256-trunc254-padded",

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -28,6 +28,7 @@ var tCodes = map[uint64]string{
 	0x1B:   "keccak-256",
 	0x1C:   "keccak-384",
 	0x1D:   "keccak-512",
+	0x1E:   "blake3",
 	0x18:   "shake-128",
 	0x19:   "shake-256",
 	0x1100: "x11",

--- a/register/all/multihash_all.go
+++ b/register/all/multihash_all.go
@@ -18,5 +18,6 @@ package all
 
 import (
 	_ "github.com/multiformats/go-multihash/register/blake2"
+	_ "github.com/multiformats/go-multihash/register/blake3"
 	_ "github.com/multiformats/go-multihash/register/sha3"
 )

--- a/register/blake3/multihash_blake3.go
+++ b/register/blake3/multihash_blake3.go
@@ -1,0 +1,23 @@
+/*
+	This package has no purpose except to register the blake3 hash function.
+
+	It is meant to be used as a side-effecting import, e.g.
+
+		import (
+			_ "github.com/multiformats/go-multihash/register/blake3"
+		)
+*/
+package blake3
+
+import (
+	"hash"
+
+	"lukechampine.com/blake3"
+
+	"github.com/multiformats/go-multihash/core"
+)
+
+func init() {
+	multihash.Register(multihash.BLAKE3, func() hash.Hash { h := blake3.New(32, nil); return h })
+
+}

--- a/test/sharness/t0030-blake3.sh
+++ b/test/sharness/t0030-blake3.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# Copyright (c) 2015 Christian Couder
+# MIT Licensed; see the LICENSE file in this repository.
+#
+
+test_description="blake3 tests"
+
+. lib/test-lib.sh
+
+test_expect_success "'multihash -a=blake3 -e=hex' succeeds" '
+	echo "Hash me!" >hash_me.txt &&
+	multihash -a=blake3 -e=hex hash_me.txt >/dev/null
+'
+
+test_hasher() {
+        INPUT_LEN=$1
+        EXPECTED=$2
+
+        test_expect_success "'multihash -a=blake3 -e=hex' output is correct (input len=$INPUT_LEN)" '
+        go run ../t0030-lib/data.go $INPUT_LEN | multihash -a=blake3 -e=hex >actual
+        echo $EXPECTED >expected
+        test_cmp expected actual
+'
+}
+
+# Copied from official test vector, see:
+#
+# https://github.com/BLAKE3-team/BLAKE3/blob/080b3330159a19407dddb407dc917925ac40c4d3/test_vectors/test_vectors.json
+
+test_hasher 0 "1e20af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262"
+test_hasher 1 "1e202d3adedff11b61f14c886e35afa036736dcd87a74d27b5c1510225d0f592e213"
+test_hasher 2 "1e207b7015bb92cf0b318037702a6cdd81dee41224f734684c2c122cd6359cb1ee63"
+test_hasher 3 "1e20e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
+test_hasher 4 "1e20f30f5ab28fe047904037f77b6da4fea1e27241c5d132638d8bedce9d40494f32"
+test_hasher 5 "1e20b40b44dfd97e7a84a996a91af8b85188c66c126940ba7aad2e7ae6b385402aa2"
+test_hasher 6 "1e2006c4e8ffb6872fad96f9aaca5eee1553eb62aed0ad7198cef42e87f6a616c844"
+test_hasher 7 "1e203f8770f387faad08faa9d8414e9f449ac68e6ff0417f673f602a646a891419fe"
+test_hasher 8 "1e202351207d04fc16ade43ccab08600939c7c1fa70a5c0aaca76063d04c3228eaeb"
+test_hasher 63 "1e20e9bc37a594daad83be9470df7f7b3798297c3d834ce80ba85d6e207627b7db7b"
+test_hasher 64 "1e204eed7141ea4a5cd4b788606bd23f46e212af9cacebacdc7d1f4c6dc7f2511b98"
+test_hasher 65 "1e20de1e5fa0be70df6d2be8fffd0e99ceaa8eb6e8c93a63f2d8d1c30ecb6b263dee"
+test_hasher 127 "1e20d81293fda863f008c09e92fc382a81f5a0b4a1251cba1634016a0f86a6bd640d"
+test_hasher 128 "1e20f17e570564b26578c33bb7f44643f539624b05df1a76c81f30acd548c44b45ef"
+test_hasher 129 "1e20683aaae9f3c5ba37eaaf072aed0f9e30bac0865137bae68b1fde4ca2aebdcb12"
+test_hasher 1023 "1e2010108970eeda3eb932baac1428c7a2163b0e924c9a9e25b35bba72b28f70bd11"
+test_hasher 1024 "1e2042214739f095a406f3fc83deb889744ac00df831c10daa55189b5d121c855af7"
+test_hasher 1025 "1e20d00278ae47eb27b34faecf67b4fe263f82d5412916c1ffd97c8cb7fb814b8444"
+test_hasher 2048 "1e20e776b6028c7cd22a4d0ba182a8bf62205d2ef576467e838ed6f2529b85fba24a"
+test_hasher 2049 "1e205f4d72f40d7a5f82b15ca2b2e44b1de3c2ef86c426c95c1af0b6879522563030"
+test_hasher 3072 "1e20b98cb0ff3623be03326b373de6b9095218513e64f1ee2edd2525c7ad1e5cffd2"
+test_hasher 3073 "1e207124b49501012f81cc7f11ca069ec9226cecb8a2c850cfe644e327d22d3e1cd3"
+test_hasher 4096 "1e20015094013f57a5277b59d8475c0501042c0b642e531b0a1c8f58d2163229e969"
+test_hasher 4097 "1e209b4052b38f1c5fc8b1f9ff7ac7b27cd242487b3d890d15c96a1c25b8aa0fb995"
+test_hasher 5120 "1e209cadc15fed8b5d854562b26a9536d9707cadeda9b143978f319ab34230535833"
+test_hasher 5121 "1e20628bd2cb2004694adaab7bbd778a25df25c47b9d4155a55f8fbd79f2fe154cff"
+test_hasher 6144 "1e203e2e5b74e048f3add6d21faab3f83aa44d3b2278afb83b80b3c35164ebeca205"
+test_hasher 6145 "1e20f1323a8631446cc50536a9f705ee5cb619424d46887f3c376c695b70e0f0507f"
+test_hasher 7168 "1e2061da957ec2499a95d6b8023e2b0e604ec7f6b50e80a9678b89d2628e99ada77a"
+test_hasher 7169 "1e20a003fc7a51754a9b3c7fae0367ab3d782dccf28855a03d435f8cfe74605e7817"
+test_hasher 8192 "1e20aae792484c8efe4f19e2ca7d371d8c467ffb10748d8a5a1ae579948f718a2a63"
+test_hasher 8193 "1e20bab6c09cb8ce8cf459261398d2e7aef35700bf488116ceb94a36d0f5f1b7bc3b"
+test_hasher 16384 "1e20f875d6646de28985646f34ee13be9a576fd515f76b5b0a26bb324735041ddde4"
+test_hasher 31744 "1e2062b6960e1a44bcc1eb1a611a8d6235b6b4b78f32e7abc4fb4c6cdcce94895c47"
+test_hasher 102400 "1e20bc3e3d41a1146b069abffad3c0d44860cf664390afce4d9661f7902e7943e085"
+
+test_done

--- a/test/sharness/t0030-lib/data.go
+++ b/test/sharness/t0030-lib/data.go
@@ -1,0 +1,55 @@
+// Generate hasher input that matches BLAKE3's test vectors.
+//
+// See:
+//
+// https://github.com/BLAKE3-team/BLAKE3/blob/080b3330159a19407dddb407dc917925ac40c4d3/test_vectors/test_vectors.json
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+var usage = `usage: %s n
+Generate n bytes of input for blake3 test vector.
+`
+
+const BYTE_LOOP = 251
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, usage, os.Args[0])
+		os.Exit(1)
+	}
+
+	c, err := strconv.ParseUint(os.Args[1], 0, 32)
+	if err != nil {
+		die(err)
+	}
+
+	var b [BYTE_LOOP]uint8
+	for i := range b {
+		b[i] = uint8(i)
+	}
+
+	for c > 0 {
+		var w uint64 = BYTE_LOOP
+		if c < BYTE_LOOP {
+			w = c
+		}
+
+		_, err := os.Stdout.Write(b[:w])
+		if err != nil {
+			die(err)
+		}
+
+		c -= w
+	}
+}
+
+func die(v ...interface{}) {
+	fmt.Fprint(os.Stderr, v...)
+	fmt.Fprint(os.Stderr, "\n")
+	os.Exit(1)
+}


### PR DESCRIPTION
This PR registers the version of BLAKE3 hashing from https://github.com/lukechampine/blake3 which now seems to have vector optimization.

- Looks like an additional v1 version of cpuid is included -- concern?
- Sharness tests use the test data from the official Rust/C version at https://github.com/BLAKE3-team/BLAKE3

Closes https://github.com/multiformats/go-multihash/issues/121