### PR TITLE
Add variations of sha2

### DIFF
--- a/core/magic.go
+++ b/core/magic.go
@@ -9,8 +9,12 @@ var ErrSumNotSupported = errors.New("no such hash registered")
 const (
 	IDENTITY     = 0x00
 	SHA1         = 0x11
+	SHA2_224     = 0x1013
 	SHA2_256     = 0x12
+	SHA2_384     = 0x20
 	SHA2_512     = 0x13
+	SHA2_512_224 = 0x1014
+	SHA2_512_256 = 0x1015
 	SHA3_224     = 0x17
 	SHA3_256     = 0x16
 	SHA3_384     = 0x15

--- a/core/registry.go
+++ b/core/registry.go
@@ -71,7 +71,11 @@ func init() {
 	Register(IDENTITY, func() hash.Hash { return &identityMultihash{} })
 	Register(MD5, md5.New)
 	Register(SHA1, sha1.New)
+	Register(SHA2_224, sha256.New224)
 	Register(SHA2_256, sha256.New)
+	Register(SHA2_384, sha512.New384)
 	Register(SHA2_512, sha512.New)
+	Register(SHA2_512_224, sha512.New512_224)
+	Register(SHA2_512_256, sha512.New512_256)
 	Register(DBL_SHA2_256, func() hash.Hash { return &doubleSha256{sha256.New()} })
 }


### PR DESCRIPTION
Corresponds to https://github.com/multiformats/multicodec/pull/234 .

Add these also to the automatically registered set, as we do for all the other hash functions that are readily available in the golang standard library.