### PR TITLE
adding tests for blake3 and fixing an error handling bug.

### DIFF
--- a/multihash.go
+++ b/multihash.go
@@ -27,11 +27,12 @@ var (
 
 // ErrInconsistentLen is returned when a decoded multihash has an inconsistent length
 type ErrInconsistentLen struct {
-	dm *DecodedMultihash
+	dm          *DecodedMultihash
+	lengthFound int
 }
 
 func (e ErrInconsistentLen) Error() string {
-	return fmt.Sprintf("multihash length inconsistent: expected %d, got %d", e.dm.Length, len(e.dm.Digest))
+	return fmt.Sprintf("multihash length inconsistent: expected len(hdig)=%d, got rlen=%d", e.dm.Length, e.lengthFound)
 }
 
 // constants
@@ -143,6 +144,7 @@ var Codes = map[uint64]string{
 	MD5:                       "md5",
 }
 
+// reads a varint from buf and returns bytes read.
 func uvarint(buf []byte) (uint64, []byte, error) {
 	n, c, err := varint.FromUvarint(buf)
 	if err != nil {
@@ -233,7 +235,7 @@ func Decode(buf []byte) (*DecodedMultihash, error) {
 	}
 
 	if len(buf) != rlen {
-		return nil, ErrInconsistentLen{dm}
+		return nil, ErrInconsistentLen{dm, rlen}
 	}
 
 	return dm, nil
@@ -264,8 +266,8 @@ func EncodeName(buf []byte, name string) ([]byte, error) {
 // Note: the returned digest is a slice over the passed in data and should be
 // copied if the buffer will be reused
 func readMultihashFromBuf(buf []byte) (int, uint64, []byte, error) {
-	bufl := len(buf)
-	if bufl < 2 {
+	initBufLength := len(buf)
+	if initBufLength < 2 {
 		return 0, 0, nil, ErrTooShort
 	}
 
@@ -289,7 +291,8 @@ func readMultihashFromBuf(buf []byte) (int, uint64, []byte, error) {
 		return 0, 0, nil, errors.New("length greater than remaining number of bytes in buffer")
 	}
 
-	rlen := (bufl - len(buf)) + int(length)
+	// rlen is the advertised size of the CID
+	rlen := (initBufLength - len(buf)) + int(length)
 	return rlen, code, buf[:length], nil
 }
 

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -59,6 +59,7 @@ var testCases = []TestCase{
 	{"d41d8cd98f00b204e9800998ecf8427e", 0xd5, "md5"},
 	{"14fcb37dc45fa9a3c492557121bd4d461c0db40e5dcfcaa98498bd238486c307", 0x1012, "sha2-256-trunc254-padded"},
 	{"14fcb37dc45fa9a3c492557121bd4d461c0db40e5dcfcaa98498bd238486c307", 0xb401, "poseidon-bls12_381-a2-fc1"},
+	{"04e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9", 0x1e, "blake3"},
 }
 
 func (tc TestCase) Multihash() (Multihash, error) {

--- a/sum_test.go
+++ b/sum_test.go
@@ -58,6 +58,7 @@ var sumTestCases = []SumTestCase{
 	{multihash.SHAKE_128, 32, "foo", "1820f84e95cb5fbd2038863ab27d3cdeac295ad2d4ab96ad1f4b070c0bf36078ef08"},
 	{multihash.SHAKE_256, 64, "foo", "19401af97f7818a28edfdfce5ec66dbdc7e871813816d7d585fe1f12475ded5b6502b7723b74e2ee36f2651a10a8eaca72aa9148c3c761aaceac8f6d6cc64381ed39"},
 	{multihash.MD5, -1, "foo", "d50110acbd18db4cc2f85cedef654fccc4a4d8"},
+	{multihash.BLAKE3, 32, "foo", "1e2004e0bb39f30b1a3feb89f536c93be15055482df748674b00d26e5a75777702e9"},
 }
 
 func TestSum(t *testing.T) {


### PR DESCRIPTION
Re-exporting blake3 constants in the right places so we can support it elsewhere (like go-verifcid, so that I can add support for approving fixed-length blake3 as a "good hash" there 😄 ) Draft because there are no tests yet.

edit: it doesn't exactly do this anymore, check comments below...