### PR TITLE
feat: add support for variable length hash functions

### DIFF
--- a/core/magic.go
+++ b/core/magic.go
@@ -5,6 +5,9 @@ import "errors"
 // ErrSumNotSupported is returned when the Sum function code is not implemented
 var ErrSumNotSupported = errors.New("no such hash registered")
 
+// ErrLenTooLarge is returned when the hash function cannot produce the requested number of bytes
+var ErrLenTooLarge = errors.New("requested length was too large for digest")
+
 // constants
 const (
 	IDENTITY      = 0x00

--- a/core/registry.go
+++ b/core/registry.go
@@ -18,7 +18,7 @@ import (
 //
 // Hashers which are available in the golang stdlib will be registered automatically.
 // Others can be added using the Register function.
-var registry = make(map[uint64]func() hash.Hash)
+var registry = make(map[uint64]func(int) (hash.Hash, bool))
 
 // Register adds a new hash to the set available from GetHasher and Sum.
 //
@@ -37,8 +37,34 @@ func Register(indicator uint64, hasherFactory func() hash.Hash) {
 	if hasherFactory == nil {
 		panic("not sensible to attempt to register a nil function")
 	}
+	maxSize := hasherFactory().Size()
+	registry[indicator] = func(size int) (hash.Hash, bool) {
+		if size > maxSize {
+			return nil, false
+		}
+		return hasherFactory(), true
+	}
+	DefaultLengths[indicator] = maxSize
+}
+
+// RegisterVariableSize is like Register, but adds a new variable-sized hasher factory that takes a
+// size hint.
+//
+// When passed -1, the hasher should produce digests with the hash-function's default length. When
+// passed a non-negative integer, the hasher should try to produce digests of at least the specified
+// size.
+func RegisterVariableSize(indicator uint64, hasherFactory func(sizeHint int) (hash.Hash, bool)) {
+	if hasherFactory == nil {
+		panic("not sensible to attempt to register a nil function")
+	}
+
+	if hasher, ok := hasherFactory(-1); !ok {
+		panic("failed to determine default hash length for hasher")
+	} else {
+		DefaultLengths[indicator] = hasher.Size()
+	}
+
 	registry[indicator] = hasherFactory
-	DefaultLengths[indicator] = hasherFactory().Size()
 }
 
 // GetHasher returns a new hash.Hash according to the indicator code number provided.
@@ -54,11 +80,26 @@ func Register(indicator uint64, hasherFactory func() hash.Hash) {
 //
 // If an error is returned, it will match `errors.Is(err, ErrSumNotSupported)`.
 func GetHasher(indicator uint64) (hash.Hash, error) {
+	return GetVariableHasher(indicator, -1)
+}
+
+// GetVariableHasher returns a new hash.Hash according to the indicator code number provided, with
+// the specified size hint.
+//
+// NOTE: The size hint is only a hint. Hashers will attempt to produce at least the number of requested bytes, but may not.
+//
+// This function can fail if either the hash code is not registered, or the passed size hint is
+// statically incompatible with the specified hash function.
+func GetVariableHasher(indicator uint64, sizeHint int) (hash.Hash, error) {
 	factory, exists := registry[indicator]
 	if !exists {
 		return nil, fmt.Errorf("unknown multihash code %d (0x%x): %w", indicator, indicator, ErrSumNotSupported)
 	}
-	return factory(), nil
+	hasher, ok := factory(sizeHint)
+	if !ok {
+		return nil, ErrLenTooLarge
+	}
+	return hasher, nil
 }
 
 // DefaultLengths maps a multihash indicator code to the output size for that hash, in units of bytes.
@@ -68,7 +109,7 @@ func GetHasher(indicator uint64) (hash.Hash, error) {
 var DefaultLengths = map[uint64]int{}
 
 func init() {
-	Register(IDENTITY, func() hash.Hash { return &identityMultihash{} })
+	RegisterVariableSize(IDENTITY, func(_ int) (hash.Hash, bool) { return &identityMultihash{}, true })
 	Register(MD5, md5.New)
 	Register(SHA1, sha1.New)
 	Register(SHA2_224, sha256.New224)

--- a/sum.go
+++ b/sum.go
@@ -1,7 +1,6 @@
 package multihash
 
 import (
-	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -12,14 +11,14 @@ import (
 // ErrSumNotSupported is returned when the Sum function code is not implemented
 var ErrSumNotSupported = mhreg.ErrSumNotSupported
 
-var ErrLenTooLarge = errors.New("requested length was too large for digest")
+var ErrLenTooLarge = mhreg.ErrLenTooLarge
 
 // Sum obtains the cryptographic sum of a given buffer. The length parameter
 // indicates the length of the resulting digest. Passing a negative value uses
 // default length values for the selected hash function.
 func Sum(data []byte, code uint64, length int) (Multihash, error) {
 	// Get the algorithm.
-	hasher, err := GetHasher(code)
+	hasher, err := mhreg.GetVariableHasher(code, length)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +34,7 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 // value uses default length values for the selected hash function.
 func SumStream(r io.Reader, code uint64, length int) (Multihash, error) {
 	// Get the algorithm.
-	hasher, err := GetHasher(code)
+	hasher, err := mhreg.GetVariableHasher(code, length)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes it possible to register hasher factories that take a size hint. Such hashers should produce at least the requested number of bytes, but may:

1. Produce fewer bytes in some cases (e.g., not enough input is available).
2. May produce more bytes (the usual case).

The caller should check the size of the produced digest to determine if it's sufficient for the caller's use-case (likely truncating it if it's too large).

NOTE: the convenience `Sum` function will handle size verification and truncation internally.

TODO:

- Add tests.
- Audit documentation.
- Audit errors.

I'm posting this as a "here's how to do it", but someone else will have to take it to completion if we want to merge this.