### PR TITLE
Encode, EncodeName: drop error from function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ func main() {
 	buf, _ := hex.DecodeString("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
 
 	// Create a new multihash with it.
-	mHashBuf, _ := multihash.EncodeName(buf, "sha1")
+	mHashBuf := multihash.EncodeName(buf, "sha1")
 	// Print the multihash as hex string
 	fmt.Printf("hex: %s\n", hex.EncodeToString(mHashBuf))
 

--- a/multihash.go
+++ b/multihash.go
@@ -243,21 +243,19 @@ func Decode(buf []byte) (*DecodedMultihash, error) {
 
 // Encode a hash digest along with the specified function code.
 // Note: the length is derived from the length of the digest itself.
-//
-// The error return is legacy; it is always nil.
-func Encode(buf []byte, code uint64) ([]byte, error) {
+func Encode(buf []byte, code uint64) []byte {
 	// FUTURE: this function always causes heap allocs... but when used, this value is almost always going to be appended to another buffer (either as part of CID creation, or etc) -- should this whole function be rethought and alternatives offered?
 	newBuf := make([]byte, varint.UvarintSize(code)+varint.UvarintSize(uint64(len(buf)))+len(buf))
 	n := varint.PutUvarint(newBuf, code)
 	n += varint.PutUvarint(newBuf[n:], uint64(len(buf)))
 
 	copy(newBuf[n:], buf)
-	return newBuf, nil
+	return newBuf
 }
 
 // EncodeName is like Encode() but providing a string name
 // instead of a numeric code. See Names for allowed values.
-func EncodeName(buf []byte, name string) ([]byte, error) {
+func EncodeName(buf []byte, name string) []byte {
 	return Encode(buf, Names[name])
 }
 

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -94,22 +94,14 @@ func TestEncode(t *testing.T) {
 
 		nb := append(pre[:n], ob...)
 
-		encC, err := Encode(ob, tc.code)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+		encC := Encode(ob, tc.code)
 
 		if !bytes.Equal(encC, nb) {
 			t.Error("encoded byte mismatch: ", encC, nb)
 			t.Error(hex.Dump(nb))
 		}
 
-		encN, err := EncodeName(ob, tc.name)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+		encN := EncodeName(ob, tc.name)
 
 		if !bytes.Equal(encN, nb) {
 			t.Error("encoded byte mismatch: ", encN, nb)
@@ -128,7 +120,7 @@ func TestEncode(t *testing.T) {
 func ExampleEncodeName() {
 	// ignores errors for simplicity - don't do that at home.
 	buf, _ := hex.DecodeString("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
-	mhbuf, _ := EncodeName(buf, "sha1")
+	mhbuf := EncodeName(buf, "sha1")
 	mhhex := hex.EncodeToString(mhbuf)
 	fmt.Printf("hex: %v\n", mhhex)
 
@@ -217,7 +209,7 @@ func TestTable(t *testing.T) {
 func ExampleDecode() {
 	// ignores errors for simplicity - don't do that at home.
 	buf, _ := hex.DecodeString("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
-	mhbuf, _ := EncodeName(buf, "sha1")
+	mhbuf := EncodeName(buf, "sha1")
 	o, _ := Decode(mhbuf)
 	mhhex := hex.EncodeToString(o.Digest)
 	fmt.Printf("obj: %v 0x%x %d %s\n", o.Name, o.Code, o.Length, mhhex)

--- a/sum.go
+++ b/sum.go
@@ -71,5 +71,5 @@ func encodeHash(hasher hash.Hash, code uint64, length int) (Multihash, error) {
 
 	// Put the multihash metainfo bytes at the front of the buffer.
 	//  FUTURE: try to improve allocations here.  Encode does several which are probably avoidable, but it's the shape of the Encode method arguments that forces this.
-	return Encode(sum, code)
+	return Encode(sum, code), nil
 }


### PR DESCRIPTION
This makes it cleaner that this function doesn't return errors, shuts up
linters complaining about ignoring errors etc.

Considering go-multihash is v0.x.y, changing that signature should be
fine.