### PR TITLE
add handler for hasher.Write returned error

### DIFF
--- a/sum.go
+++ b/sum.go
@@ -24,7 +24,9 @@ func Sum(data []byte, code uint64, length int) (Multihash, error) {
 	}
 
 	// Feed data in.
-	hasher.Write(data)
+	if _, err = hasher.Write(data); err != nil {
+		return nil, err
+	}
 
 	return encodeHash(hasher, code, length)
 }


### PR DESCRIPTION
Propagate non-nil error from `hasher.Write` up the call stack.
Resolves https://github.com/multiformats/go-multihash/issues/166