### PR TITLE
perf: outline logic in Decode to allow for stack allocations

### DIFF
--- a/allocate_go119_test.go
+++ b/allocate_go119_test.go
@@ -1,0 +1,11 @@
+//go:build !go1.20
+
+package multihash
+
+import "testing"
+
+func mustNotAllocateMore(_ *testing.T, _ float64, f func()) {
+	// the compiler isn't able to detect our outlined stack allocation on before
+	// 1.20 so let's not test for it. We don't mind if outdated versions are slightly slower.
+	f()
+}

--- a/allocate_go120_test.go
+++ b/allocate_go120_test.go
@@ -1,0 +1,12 @@
+//go:build go1.20
+
+package multihash
+
+import "testing"
+
+func mustNotAllocateMore(t *testing.T, n float64, f func()) {
+	t.Helper()
+	if b := testing.AllocsPerRun(10, f); b > n {
+		t.Errorf("it allocated %f max %f !", b, n)
+	}
+}

--- a/multihash_test.go
+++ b/multihash_test.go
@@ -151,27 +151,29 @@ func TestDecode(t *testing.T) {
 
 		nb := append(pre[:n], ob...)
 
-		dec, err := Decode(nb)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+		mustNotAllocateMore(t, 0, func() {
+			dec, err := Decode(nb)
+			if err != nil {
+				t.Error(err)
+				return
+			}
 
-		if dec.Code != tc.code {
-			t.Error("decoded code mismatch: ", dec.Code, tc.code)
-		}
+			if dec.Code != tc.code {
+				t.Error("decoded code mismatch: ", dec.Code, tc.code)
+			}
 
-		if dec.Name != tc.name {
-			t.Error("decoded name mismatch: ", dec.Name, tc.name)
-		}
+			if dec.Name != tc.name {
+				t.Error("decoded name mismatch: ", dec.Name, tc.name)
+			}
 
-		if dec.Length != len(ob) {
-			t.Error("decoded length mismatch: ", dec.Length, len(ob))
-		}
+			if dec.Length != len(ob) {
+				t.Error("decoded length mismatch: ", dec.Length, len(ob))
+			}
 
-		if !bytes.Equal(dec.Digest, ob) {
-			t.Error("decoded byte mismatch: ", dec.Digest, ob)
-		}
+			if !bytes.Equal(dec.Digest, ob) {
+				t.Error("decoded byte mismatch: ", dec.Digest, ob)
+			}
+		})
 	}
 }
 
@@ -242,15 +244,20 @@ func TestCast(t *testing.T) {
 
 		nb := append(pre[:n], ob...)
 
-		if _, err := Cast(nb); err != nil {
-			t.Error(err)
-			continue
-		}
+		mustNotAllocateMore(t, 0, func() {
+			if _, err := Cast(nb); err != nil {
+				t.Error(err)
+				return
+			}
+		})
 
-		if _, err = Cast(ob); err == nil {
-			t.Error("cast failed to detect non-multihash")
-			continue
-		}
+		// 1 for the error object.
+		mustNotAllocateMore(t, 1, func() {
+			if _, err = Cast(ob); err == nil {
+				t.Error("cast failed to detect non-multihash")
+				return
+			}
+		})
 	}
 }
 
@@ -343,8 +350,29 @@ func BenchmarkDecode(b *testing.B) {
 	pre[1] = byte(uint8(len(ob)))
 	nb := append(pre, ob...)
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		Decode(nb)
+	}
+}
+
+func BenchmarkCast(b *testing.B) {
+	tc := testCases[0]
+	ob, err := hex.DecodeString(tc.hex)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+
+	pre := make([]byte, 2)
+	pre[0] = byte(uint8(tc.code))
+	pre[1] = byte(uint8(len(ob)))
+	nb := append(pre, ob...)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Cast(nb)
 	}
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-	"version": "v0.2.2"
+	"version": "v0.2.3"
 }


### PR DESCRIPTION
I took extra efforts for this to be a backward compatible change, I think `DecodedMultihash` should return a value struct not a pointer.

I also updated the error type to a value because this allows for 1 instead of 2 allocations when erroring.

```
name       old time/op    new time/op    delta
Decode-12     102ns ± 3%      18ns ± 3%   -82.47%  (p=0.000 n=9+9)

name       old alloc/op   new alloc/op   delta
Decode-12     64.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name       old allocs/op  new allocs/op  delta
Decode-12      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

I originally found this problem by benchmarking `go-cid`:
```
github.com/ipfs/go-cid.CidFromBytes

/home/hugo/go/pkg/mod/github.com/ipfs/go-cid@v0.4.0/cid.go

  Total:      4.64GB    10.75GB (flat, cum)   100%
    638            .          .           	if len(data) > 2 && data[0] == mh.SHA2_256 && data[1] == 32 {
    639            .          .           		if len(data) < 34 {
    640            .          .           			return 0, Undef, ErrInvalidCid{fmt.Errorf("not enough bytes for cid v0")}
    641            .          .           		}
    642            .          .
    643            .     6.11GB           		h, err := mh.Cast(data[:34])
                                                               _, err := Decode(buf)                                        multihash.go:215

    644            .          .           		if err != nil {
    645            .          .           			return 0, Undef, ErrInvalidCid{err}
    646            .          .           		}
```

We can see it call `mh.Cast` and `mh.Cast` call `Decode` and instantly drops the `DecodedMultihash`. The point of this is purely to validate the multihash.