### PR TITLE
chore: we only support installing from source

### DIFF
--- a/multihash/README.md
+++ b/multihash/README.md
@@ -6,11 +6,9 @@ Warning: this is a **multihash** tool! Its digests follow the [multihash](https:
 
 ### Install
 
-- From Source:
-    ```
-    go get github.com/multiformats/go-multihash/multihash
-    ```
-- Precompiled Binaries: https://gobuilder.me/github.com/multiformats/go-multihash/multihash
+```
+go get github.com/multiformats/go-multihash/multihash@latest
+```
 
 ### Usage
 


### PR DESCRIPTION
gobuilder.me is dead, and it's only a matter of time before someone starts to distribute malware from this domain...